### PR TITLE
feat(sidecar): no longer store Webmention targets

### DIFF
--- a/eagle/sidecar.go
+++ b/eagle/sidecar.go
@@ -9,7 +9,6 @@ type Mention struct {
 }
 
 type Sidecar struct {
-	Targets      []string   `json:"targets,omitempty"`
 	Context      *xray.Post `json:"context,omitempty"`
 	Replies      []*Mention `json:"replies,omitempty"`
 	Interactions []*Mention `json:"interactions,omitempty"`
@@ -20,8 +19,7 @@ func (s *Sidecar) MentionsCount() int {
 }
 
 func (s *Sidecar) Empty() bool {
-	return len(s.Targets) == 0 &&
-		s.Context == nil &&
+	return s.Context == nil &&
 		len(s.Replies) == 0 &&
 		len(s.Interactions) == 0
 }

--- a/fs/sidecar.go
+++ b/fs/sidecar.go
@@ -28,10 +28,6 @@ func (f *FS) getSidecar(entry *eagle.Entry) (*eagle.Sidecar, string, error) {
 		sidecar = &eagle.Sidecar{}
 	}
 
-	if sidecar.Targets == nil {
-		sidecar.Targets = []string{}
-	}
-
 	if sidecar.Replies == nil {
 		sidecar.Replies = []*eagle.Mention{}
 	}

--- a/webmentions/send.go
+++ b/webmentions/send.go
@@ -18,7 +18,7 @@ import (
 func (ws *Webmentions) SendWebmentions(old, new *eagle.Entry) error {
 	var targets []string
 
-	if old != nil && !old.NoSendInteractions && !old.Draft && !old.Deleted {
+	if canSendWebmentions(old) {
 		oldTargets, err := ws.getTargetsFromHTML(old)
 		if err != nil {
 			return err
@@ -26,7 +26,7 @@ func (ws *Webmentions) SendWebmentions(old, new *eagle.Entry) error {
 		targets = append(targets, oldTargets...)
 	}
 
-	if new != nil && !new.NoSendInteractions && !new.Draft && !new.Deleted {
+	if canSendWebmentions(new) {
 		newTargets, err := ws.getTargetsFromHTML(new)
 		if err != nil {
 			return err
@@ -98,6 +98,14 @@ func (ws *Webmentions) sendWebmention(source, target string) error {
 	defer res.Body.Close()
 
 	return nil
+}
+
+func canSendWebmentions(e *eagle.Entry) bool {
+	return e != nil &&
+		!e.NoSendInteractions &&
+		!e.Draft &&
+		!e.Deleted &&
+		e.Listing == nil
 }
 
 func isPrivate(urlStr string) bool {

--- a/webmentions/send.go
+++ b/webmentions/send.go
@@ -18,7 +18,7 @@ import (
 func (ws *Webmentions) SendWebmentions(old, new *eagle.Entry) error {
 	var targets []string
 
-	if old != nil && !old.NoSendInteractions && !old.Draft {
+	if old != nil && !old.NoSendInteractions && !old.Draft && !old.Deleted {
 		oldTargets, err := ws.getTargetsFromHTML(old)
 		if err != nil {
 			return err
@@ -26,7 +26,7 @@ func (ws *Webmentions) SendWebmentions(old, new *eagle.Entry) error {
 		targets = append(targets, oldTargets...)
 	}
 
-	if new != nil && !new.NoSendInteractions && !new.Draft {
+	if new != nil && !new.NoSendInteractions && !new.Draft && !new.Deleted {
 		newTargets, err := ws.getTargetsFromHTML(new)
 		if err != nil {
 			return err

--- a/webmentions/send.go
+++ b/webmentions/send.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	urlpkg "net/url"
-	"os"
 
 	"github.com/hacdias/eagle/eagle"
 	"github.com/hacdias/eagle/renderer"
@@ -16,75 +15,43 @@ import (
 	"willnorris.com/go/webmention"
 )
 
-func (ws *Webmentions) SendWebmentions(e *eagle.Entry) error {
-	if e.NoSendInteractions ||
-		e.Draft {
-		return nil
+func (ws *Webmentions) SendWebmentions(old, new *eagle.Entry) error {
+	var targets []string
+
+	if old != nil && !old.NoSendInteractions && !old.Draft {
+		oldTargets, err := ws.getTargetsFromHTML(old)
+		if err != nil {
+			return err
+		}
+		targets = append(targets, oldTargets...)
 	}
 
-	all, curr, _, err := ws.GetWebmentionTargets(e)
-	if err != nil {
-		return err
+	if new != nil && !new.NoSendInteractions && !new.Draft {
+		newTargets, err := ws.getTargetsFromHTML(new)
+		if err != nil {
+			return err
+		}
+		targets = append(targets, newTargets...)
 	}
+
+	targets = lo.Uniq(targets)
 
 	var errs *multierror.Error
 
-	for _, target := range all {
-		// if strings.HasPrefix(target, e.Config.Site.BaseURL) {
-		// TODO: it is a self-mention.
-		// }
-
-		err := ws.sendWebmention(e.Permalink, target)
+	for _, target := range targets {
+		err := ws.sendWebmention(new.Permalink, target)
 		if err != nil && !errors.Is(err, webmention.ErrNoEndpointFound) {
 			err = fmt.Errorf("send webmention error %s: %w", target, err)
 			errs = multierror.Append(errs, err)
 		}
 	}
 
-	if !e.Deleted {
-		// If it's not a deleted entry, update the targets list.
-		err = ws.fs.UpdateSidecar(e, func(data *eagle.Sidecar) (*eagle.Sidecar, error) {
-			data.Targets = curr
-			return data, nil
-		})
-
-		errs = multierror.Append(errs, err)
-	}
-
-	err = errs.ErrorOrNil()
-	if err == nil {
-		return nil
-	}
-
-	return fmt.Errorf("webmention errors for %s: %w", e.ID, err)
-}
-
-func (ws *Webmentions) GetWebmentionTargets(entry *eagle.Entry) ([]string, []string, []string, error) {
-	currentTargets, err := ws.getTargetsFromHTML(entry)
+	err := errs.ErrorOrNil()
 	if err != nil {
-		if os.IsNotExist(err) {
-			if entry.Deleted {
-				currentTargets = []string{}
-			} else {
-				return nil, nil, nil, fmt.Errorf("entry should exist as it is not deleted %s: %w", entry.ID, err)
-			}
-		} else {
-			return nil, nil, nil, err
-		}
+		return fmt.Errorf("webmention errors for %s: %w", new.ID, err)
 	}
 
-	sidecar, err := ws.fs.GetSidecar(entry)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	oldTargets := sidecar.Targets
-	oldTargets = lo.Uniq(oldTargets)
-
-	targets := append(currentTargets, oldTargets...)
-	targets = lo.Uniq(targets)
-
-	return targets, currentTargets, oldTargets, nil
+	return nil
 }
 
 func (ws *Webmentions) getTargetsFromHTML(entry *eagle.Entry) ([]string, error) {

--- a/webmentions/webmentions.go
+++ b/webmentions/webmentions.go
@@ -36,12 +36,12 @@ func NewWebmentions(fs *fs.FS, notifier eagle.Notifier, renderer *renderer.Rende
 	}
 }
 
-func (ws *Webmentions) EntryHook(_, e *eagle.Entry) error {
-	if e.Listing != nil {
+func (ws *Webmentions) EntryHook(old, new *eagle.Entry) error {
+	if new.Listing != nil {
 		return nil
 	}
 
-	return ws.SendWebmentions(e)
+	return ws.SendWebmentions(old, new)
 }
 
 func isInteraction(post *eagle.Mention) bool {

--- a/webmentions/webmentions.go
+++ b/webmentions/webmentions.go
@@ -37,10 +37,6 @@ func NewWebmentions(fs *fs.FS, notifier eagle.Notifier, renderer *renderer.Rende
 }
 
 func (ws *Webmentions) EntryHook(old, new *eagle.Entry) error {
-	if new.Listing != nil {
-		return nil
-	}
-
 	return ws.SendWebmentions(old, new)
 }
 


### PR DESCRIPTION
Since 5953dd36fdaf5afe40449f5c77633880a45a6024, `EntryHook` receives both the old and the new entry. We can use this to calculate the old and new targets in real time, instead of storing them in the sidecar. Space optimization.